### PR TITLE
Potential fix for code scanning alert no. 1: Disabled Spring CSRF protection

### DIFF
--- a/src/main/java/br/com/vr/autorizador/config/WebSecurityConfig.java
+++ b/src/main/java/br/com/vr/autorizador/config/WebSecurityConfig.java
@@ -49,7 +49,22 @@ public class WebSecurityConfig {
 	@Bean
     protected SecurityFilterChain filterChain(final HttpSecurity http) throws Exception {
 		 http
-         .csrf(CsrfConfigurer::disable)
+         .csrf(csrf -> csrf
+             .ignoringRequestMatchers(
+                 "/", 
+                 "/docs",
+                 "/v2/api-docs/**",        // swagger
+                 "/webjars/**",            // swagger-ui webjars
+                 "/swagger-resources/**",  // swagger-ui resources
+                 "/configuration/**",      // swagger configuration
+                 "/swagger-ui/**",
+                 "/*.html",
+                 "/favicon.ico",
+                 "/**/*.html",
+                 "/**/*.css",
+                 "/**/*.js"
+             )
+         )
          .authorizeHttpRequests((authorize) -> authorize
              .requestMatchers(
                      "/",


### PR DESCRIPTION
Potential fix for [https://github.com/matcarv/vr-autorizador-api/security/code-scanning/1](https://github.com/matcarv/vr-autorizador-api/security/code-scanning/1)

To fix this problem, CSRF protection should not be universally disabled. The best approach is to enable CSRF protection for all endpoints, or, if necessary, selectively disable it only for endpoints confirmed to be safe (such as Swagger or documentation endpoints, if these do not allow state-changing requests). You can achieve selective disabling by configuring the `csrf` handler to ignore specific paths, rather than invoking `.disable()` wholesale. This preserves CSRF protection for all other endpoints and minimizes the attack surface.

In `src/main/java/br/com/vr/autorizador/config/WebSecurityConfig.java`, change the code in the `filterChain` bean method:
- Replace `.csrf(CsrfConfigurer::disable)` with a configuration that enables CSRF by default, but ignores it for the documentation/static asset endpoints.
- This is done with `.csrf(csrf -> csrf.ignoringRequestMatchers(/* matchers here */))`.

No additional dependencies are required; only minor edits to the method in this existing file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
